### PR TITLE
Fixed ECR output name that prevents action from work

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ runs:
       shell: bash
     - name: Helm Chart
       env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REGISTRY: ${{ steps.ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ inputs.ecr-repo-name }}
           HELM_EXPERIMENTAL_OCI: "1"
       run : |


### PR DESCRIPTION
Fixed error that prevent this action from normal work

Was: 
<img width="1074" alt="Screenshot 2023-10-19 at 12 22 33" src="https://github.com/explorium-ai/package-helm-ecr-action/assets/24703846/b7a6a98b-9dd2-417e-ae8e-a00523942225">

Now:
<img width="1043" alt="Screenshot 2023-10-19 at 12 23 24" src="https://github.com/explorium-ai/package-helm-ecr-action/assets/24703846/fa6cfe25-8ee7-416e-8e3f-57df994d4162">
